### PR TITLE
Add a regex to check if auth must be done

### DIFF
--- a/Resources/config/packages/univ_lorraine_symfony_cas.yaml
+++ b/Resources/config/packages/univ_lorraine_symfony_cas.yaml
@@ -7,4 +7,4 @@ univ_lorraine_symfony_cas:
   cas_login_redirect: / # optional (default: /)
   cas_logout_redirect: ~ # optional (must be a public area)
   cas_version: "3.0" # optional (default: 2.0)
-
+  public_access_regex : ~ # a regex that match publicly accessible URLs but give user if authenticated

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -66,6 +66,11 @@ class Configuration implements ConfigurationInterface
                     ->example('2.0')
                     ->info('Version of the CAS Server.')
                 ->end()
+                ->scalarNode('public_access_regex')
+                    ->defaultValue('')
+                    ->example('#^/(public|other/(sub1|sub2))$#')
+                    ->info('a regex that match publicly accessible URLs but give user if authenticated')
+                ->end()
             ->end()
         ;
 

--- a/src/Security/CasAuthenticator.php
+++ b/src/Security/CasAuthenticator.php
@@ -51,6 +51,11 @@ class CasAuthenticator extends AbstractAuthenticator implements AuthenticationEn
      */
     public function supports(Request $request): ?bool
     {
+        if ($this->casService->public_access_regex
+            && preg_match($this->casService->public_access_regex, $request->getRequestUri())) {
+            return false;
+        }
+
         // If user already connected, skip the CAS auth
         return !$this->security->getUser();
     }

--- a/src/Services/CasAuthenticationService.php
+++ b/src/Services/CasAuthenticationService.php
@@ -16,7 +16,7 @@ class CasAuthenticationService
     private string $cas_login_redirect;
     private string $cas_logout_redirect;
     private string $cas_version;
-
+    public string $public_access_regex;
 
     public function __construct(array $config, string $env)
     {
@@ -28,6 +28,7 @@ class CasAuthenticationService
         $this->cas_login_redirect =  ltrim($config['cas_login_redirect'], '/\\');
         $this->cas_logout_redirect = $config['cas_logout_redirect'] ?: '';
         $this->cas_version = $config['cas_version'];
+        $this->public_access_regex = $config['public_access_regex'] ?: '';
         $this->env = $env;
     }
 


### PR DESCRIPTION
Sur une page définie comme accessible à tous dans le security.yaml, 
```
    access_control:
        - { path: ^/public, roles: PUBLIC_ACCESS }
```
on a parfois besoin de récupérer le user lorsqu'il existe (le rediriger, lui afficher un contenu différent ...)
Actuellement ce n'est pas possible.
L'ajout d'un paramètre dans la config du bundle doit permettre de le faire.
Il faut donc, ajouter dans cette regex TOUTES les routes définies comme publiques pour lesquelles on veut pouvoir récupérer le user